### PR TITLE
Update njuthesis.dtx

### DIFF
--- a/njuthesis.dtx
+++ b/njuthesis.dtx
@@ -1447,6 +1447,8 @@
 % \end{note}
 %    \begin{macrocode}
 \RequirePackage[CJKnumber,CJKchecksingle]{xeCJK}
+\RequirePackage{CJKnumb} 
+%%修改此处为修正中文导致的，\chapter Undefined control sequence 错误 http://tex.stackexchange.com/questions/210397/renewcommand-the-chapter-in-chinese-problem
 %    \end{macrocode}
 %
 % 让{\XeLaTeX}能够处理dash的惯例(使用"--"和"---"获得较长的dash)。


### PR DESCRIPTION
在Mac环境中,新的texlive会报错。CJKnumber 已经被弃用，所以添加CJKnumb才能编译通过。
修正由中文导致的，\chapter Undefined control sequence 错误 
参考 http://tex.stackexchange.com/questions/210397/renewcommand-the-chapter-in-chinese-problem