### PR TITLE
研究方向置于指导教师之前；使用xeCJKfntef代替CJKfntef

### DIFF
--- a/njuthesis.dtx
+++ b/njuthesis.dtx
@@ -3134,10 +3134,10 @@ December\fi
       & \njutunderline[310pt]{\njut@value@author}\\
       \makebox[7em][s]{\njut@cap@cover@major}
       & \njutunderline[310pt]{\njut@value@major}\\
-      \makebox[7em][s]{\njut@cap@cover@supervisor}
-      & \njutunderline[310pt]{\njut@value@supervisor}\\
       \makebox[7em][s]{\njut@cap@cover@researchfield}
       & \njutunderline[310pt]{\njut@value@researchfield}\\
+      \makebox[7em][s]{\njut@cap@cover@supervisor}
+      & \njutunderline[310pt]{\njut@value@supervisor}\\
     \end{tabular}\egroup}\\
     \vskip \stretch{1}
     {\bf\kaishu\zihao{4}\njut@value@date}

--- a/njuthesis.dtx
+++ b/njuthesis.dtx
@@ -1483,14 +1483,14 @@
 \punctstyle{plain}
 %    \end{macrocode}
 %
-% |CJKfntef|宏包提供了中文下划线命令\cs{CJKunderline}，它将在制作论文封面时用到。
+% |xeCJKfntef|宏包提供了中文下划线命令\cs{CJKunderline}，它将在制作论文封面时用到。
 %    \begin{macrocode}
-\RequirePackage{CJKfntef}
+\RequirePackage{xeCJKfntef}
 %    \end{macrocode}
 %
 % 设置中文下划线颜色为黑色。
 %    \begin{macrocode}
-\renewcommand*{\CJKunderlinecolor}{\color{black}}
+\xeCJKsetup { underline/format = \color{black} }
 %    \end{macrocode}
 %
 % 使用|indentfirst|宏包支持首行缩进。


### PR DESCRIPTION
更改了两处。第二处：改为使用xeCJKfntef，不知道低版本的xeCJK支持不支持。反正如果使用CJKfntef，在高版本中下划线用`\renewcommand*{\CJKunderlinecolor}{\color{black}}`无法更改
